### PR TITLE
Ability innate energy generation

### DIFF
--- a/contract/src/generate.js
+++ b/contract/src/generate.js
@@ -34,14 +34,14 @@ const decK_increments = [1, 2, 3, 4];
 const gen_player_dmg = () => max_enemies.map((enemy) => `const player_damage_${enemy} = (${gen_base_player_dmg(enemy)} + ${gen_energy_player_dmg(enemy)}) as Uint<32>;`).join('\n    ');
 
 const gen_base_player_dmg = (enemy) => abilities.map((a) => `((abilities[${a}].effect.is_some && (abilities[${a}].effect.value.is_aoe || target == ${enemy})) as Uint<1>) * effect_damage(abilities[${a}].effect.value, battle.stats[${enemy}])`).join(' + ');
-const gen_energy_player_dmg = (enemy) => abilities.map((a) => colors.map((c) => `((abilities[${a}].on_energy[${c}].is_some && (abilities[${a}].on_energy[${c}].value.is_aoe || target == ${enemy})) as Uint<1>) * effect_damage(abilities[${a}].on_energy[${c}].value, battle.stats[${enemy}])`).join(' + ')).join(' + ');
+const gen_energy_player_dmg = (enemy) => abilities.map((a) => colors.map((c) => `((abilities[${a}].on_energy[${c}].is_some && ${generates_color(a, c)} && (abilities[${a}].on_energy[${c}].value.is_aoe || target == ${enemy})) as Uint<1>) * effect_damage(abilities[${a}].on_energy[${c}].value, battle.stats[${enemy}])`).join(' + ')).join(' + ');
 
 const gen_player_block = () => `const player_block = (${gen_base_player_block()} + ${gen_energy_player_block()}) as Uint<32>;`;
 
 const gen_base_player_block = () => abilities.map((a) => `((abilities[${a}].effect.is_some as Uint<1>) * ((abilities[${a}].effect.value.effect_type == EFFECT_TYPE.block) as Uint<1>) * abilities[${a}].effect.value.amount)`).join(' + ');
-const gen_energy_player_block = () => abilities.map((a) => colors.map((c) => `((abilities[${a}].on_energy[${c}].is_some as Uint<1>) * ((abilities[${a}].on_energy[${c}].value.effect_type == EFFECT_TYPE.block) as Uint<1>) * abilities[${a}].on_energy[${c}].value.amount)`).join(' + ')).join(' + ');
+const gen_energy_player_block = () => abilities.map((a) => colors.map((c) => `(((abilities[${a}].on_energy[${c}].is_some && ${generates_color(a, c)}) as Uint<1>) * ((abilities[${a}].on_energy[${c}].value.effect_type == EFFECT_TYPE.block) as Uint<1>) * abilities[${a}].on_energy[${c}].value.amount)`).join(' + ')).join(' + ');
 
-
+const generates_color = (a, c) => `(${abilities.filter((a2) => a != a2).map((a2) => `(abilities[${a2}].generate_color.is_some && abilities[${a2}].generate_color.value == ${c})`).join(' || ')})`;
 
 // enemy
 

--- a/contract/src/template.compact
+++ b/contract/src/template.compact
@@ -12,7 +12,6 @@ export enum EFFECT_TYPE {
     attack_fire,
     attack_ice,
     block,
-    generate,
 }
 
 // a note on attack base damage:
@@ -20,7 +19,6 @@ export enum EFFECT_TYPE {
 // TODO: how to handle this in the UI? Multiply by 10? or 5 to get 'average' with >5 being 'resistance' and <5 being 'weakness'?
 export struct Effect {
     effect_type: EFFECT_TYPE,
-    // base damage for attacks, defense for blocks, type of energy for generation (range [0, 2] only)
     amount: Uint<32>,
     is_aoe: Boolean,
 }
@@ -29,6 +27,8 @@ export struct Ability {
     effect: Maybe<Effect>,
     // effects triggered by energy generation. one energy triggers all corresponding effects of all abilities
     on_energy: Vector<3, Maybe<Effect>>,
+    // which type of energy to generate
+    generate_color: Maybe<Uint<0..2>>,
 }
 
 export struct EnemyStats {
@@ -61,7 +61,7 @@ export sealed ledger ability_base_block_id: Field;
 export sealed ledger ability_base_fire_aoe_id: Field;
 export sealed ledger ability_base_ice_id: Field;
 
-// used only be JS impl. TODO: remove or make JS and contract match once byte indexing works
+// used only by JS impl. TODO: remove or make JS and contract match once byte indexing works
 export pure circuit hashUtil(nonce1: Bytes<32>, nonce2: Field): Field {
     return transient_commit<Bytes<32>>(nonce1, nonce2);
 }
@@ -73,16 +73,14 @@ export pure circuit fakeTempRng(state: BattleState, config: BattleConfig): Bytes
 
 // ranks how "good" an ability is. higher is better. useful for ordering in the UI
 export pure circuit ability_score(ability: Ability): Uint<32> {
-    return (3 * effect_score(ability.effect) + effect_score(ability.on_energy[0]) + effect_score(ability.on_energy[1]) + effect_score(ability.on_energy[2])) as Uint<32>;
+    return ((3 * effect_score(ability.effect) + effect_score(ability.on_energy[0]) + effect_score(ability.on_energy[1]) + effect_score(ability.on_energy[2])) * (2 + (ability.generate_color.is_some as Uint<1>))) as Uint<32>;
 }
 
 // ranks how "good" an effect is. higher is better
 pure circuit effect_score(effect: Maybe<Effect>): Uint<32> {
     const aoe = (1 + (effect.value.is_aoe as Uint<1>));
-    const gen = ((effect.value.effect_type == EFFECT_TYPE.generate) as Uint<1>) * 3;
-    const non_gen = ((effect.value.effect_type != EFFECT_TYPE.generate) as Uint<1>) * effect.value.amount;
     const attack_compensate = (1 + 4 * ((effect.value.effect_type == EFFECT_TYPE.attack_phys || effect.value.effect_type == EFFECT_TYPE.attack_ice || effect.value.effect_type == EFFECT_TYPE.attack_fire) as Uint<1>));
-    return ((effect.is_some as Uint<1>) * ((aoe * non_gen * attack_compensate) + gen)) as Uint<32>;
+    return ((effect.is_some as Uint<1>) * (effect.value.amount * aoe * attack_compensate)) as Uint<32>;
 }
 
 // starting 4 abilities
@@ -93,7 +91,8 @@ export pure circuit ability_base_phys(): Ability {
             2,
             false
         }),
-        [none<Effect>(), none<Effect>(), none<Effect>()]
+        [none<Effect>(), none<Effect>(), none<Effect>()],
+        none<Uint<0..2>>()
     };
 }
 
@@ -104,7 +103,8 @@ export pure circuit ability_base_block(): Ability {
             10,
             false
         }),
-        [none<Effect>(), none<Effect>(), none<Effect>()]
+        [none<Effect>(), none<Effect>(), none<Effect>()],
+        none<Uint<0..2>>()
     };
 }
 
@@ -115,7 +115,8 @@ export pure circuit ability_base_fire_aoe(): Ability {
             2,
             true
         }),
-        [none<Effect>(), none<Effect>(), none<Effect>()]
+        [none<Effect>(), none<Effect>(), none<Effect>()],
+        none<Uint<0..2>>()
     };
 }
 
@@ -126,7 +127,8 @@ export pure circuit ability_base_ice(): Ability {
             4,
             false
         }),
-        [none<Effect>(), none<Effect>(), none<Effect>()]
+        [none<Effect>(), none<Effect>(), none<Effect>()],
+        none<Uint<0..2>>()
     };
 }
 
@@ -489,9 +491,4 @@ circuit combat_round_impl(battle_id: Field, abilities: Vector<3, Ability>, targe
 // total damage (after resistances) done by an effect to an enemy
 export pure circuit effect_damage(effect: Effect, stats: EnemyStats): Uint<32> {
     return ((((effect.effect_type == EFFECT_TYPE.attack_phys) as Uint<1>) * (10 - stats.physical_def) * effect.amount + ((effect.effect_type == EFFECT_TYPE.attack_fire) as Uint<1>) * (10 - stats.fire_def) * (effect.amount)) + ((effect.effect_type == EFFECT_TYPE.attack_ice) as Uint<1>) * (10 - stats.ice_def) * effect.amount) as Uint<32>;
-}
-
-// whether an ability generates a certain color (type) of energy
-pure circuit generates_color(color: Uint<32>, ability: Ability): Boolean {
-    return ability.effect.is_some && ability.effect.value.effect_type == EFFECT_TYPE.generate && ability.effect.value.amount == color;
 }

--- a/phaser/src/ability.ts
+++ b/phaser/src/ability.ts
@@ -33,12 +33,22 @@ function addEffectIcons(container: Phaser.GameObjects.Container, effect: Effect,
             uiComponents.push(addScaledImage(container.scene, xOffset + 24, yOffset, 'block'));
             uiComponents.push(container.scene.add.text(xOffset - 4, yOffset - 6, effect.amount.toString(), fontStyle(8)).setOrigin(0.5, 0.5));
             break;
-        case EFFECT_TYPE.generate:
-            uiComponents.push(addScaledImage(container.scene, xOffset + 24, yOffset, `energy_${effect.amount}`));
-            break;
     }
     uiComponents.forEach((comp) => container.add(comp));
     return uiComponents;
+}
+
+export function energyToHexColor(energyColor: number): string {
+    // TODO: replace with reference to palette once we finalize the energy art
+    switch (energyColor) {
+        case 0:
+            return '1f1ba6';
+        case 1:
+            return '1ba65b';
+        case 2:
+            return 'a61ba5';
+    }
+    return '000000';
 }
 
 export class AbilityWidget extends Phaser.GameObjects.Container {
@@ -51,6 +61,9 @@ export class AbilityWidget extends Phaser.GameObjects.Container {
         super(scene, x, y);
         this.setSize(96, 150);
         this.bg = scene.add.nineslice(0, 0, 'stone_button', undefined, 96, 150, 8, 8, 8, 8);
+        if (ability.generate_color.is_some) {
+            this.bg.setTint(Phaser.Display.Color.HexStringToColor(energyToHexColor(Number(ability.generate_color.value))).color);
+        }
         this.ability = ability;
         this.baseEffectUI = [];
         this.energyEffectUI = [[], [], []];
@@ -70,17 +83,4 @@ export class AbilityWidget extends Phaser.GameObjects.Container {
 
         scene.add.existing(this);
     }
-}
-
-function randomAbility(): Ability {
-    const randomEffect = (enabled: boolean) => {
-        return {
-            is_some: enabled,
-            value: { effect_type: Phaser.Math.Between(0, 3) as EFFECT_TYPE, amount: BigInt(Phaser.Math.Between(1, 4)), is_aoe: false},
-        };
-    };
-    return {
-        effect: randomEffect(true),
-        on_energy: [randomEffect(false), randomEffect(false), randomEffect(false)],
-    };
 }

--- a/phaser/src/main.tsx
+++ b/phaser/src/main.tsx
@@ -18,7 +18,7 @@ function getNetworkId(): NetworkId {
         case 'testnet':
             return NetworkId.TestNet;
         default:
-            console.error('Unknown Vite MODE, defaulting to undeployed');
+            console.error(`Unknown Vite MODE ${import.meta.env.MODE}, defaulting to undeployed`);
             return NetworkId.Undeployed;
     }
 }

--- a/phaser/src/menus/battle.ts
+++ b/phaser/src/menus/battle.ts
@@ -107,9 +107,6 @@ export class ActiveBattle extends Phaser.Scene {
                         case EFFECT_TYPE.block:
                             this.player?.addBlock(amounts[0]);
                             break;
-                        case EFFECT_TYPE.generate:
-                            // TODO
-                            break;
                     }
                     if (damageType != undefined) {
                         for (let i = 0; i < targets.length; ++i) {
@@ -316,9 +313,7 @@ class Actor extends Phaser.GameObjects.Container {
     }
 }
 
-// amount is only here to tell what type of generation it is
-// TODO DECISION: should this be the case? the re-use. or should it be separate generation types???
-export function effectTypeToIcon(effectType: EFFECT_TYPE, amount: number): string {
+export function effectTypeToIcon(effectType: EFFECT_TYPE): string {
     switch (effectType) {
         case EFFECT_TYPE.attack_fire:
             return 'fire';
@@ -328,8 +323,6 @@ export function effectTypeToIcon(effectType: EFFECT_TYPE, amount: number): strin
             return 'physical';
         case EFFECT_TYPE.block:
             return 'block';
-        case EFFECT_TYPE.generate:
-            return `energy_${amount}`;                                                    
     }
 }
 
@@ -337,10 +330,8 @@ export class BattleEffect extends Phaser.GameObjects.Container {
     constructor(scene: Phaser.Scene, x: number, y: number, effectType: EFFECT_TYPE, amount: number, onComplete: () => void) {
         super(scene, x, y);
 
-        if (effectType != EFFECT_TYPE.generate) {
-            this.add(scene.add.text(12, 0, amount.toString(), fontStyle(12)));
-        }
-        this.add(scene.add.sprite(-12, 0, effectTypeToIcon(effectType, amount)).setScale(4.0));
+        this.add(scene.add.text(12, 0, amount.toString(), fontStyle(12)));
+        this.add(scene.add.sprite(-12, 0, effectTypeToIcon(effectType)).setScale(4.0));
 
         this.setSize(48, 48);
         //console.log(`BattleEffect START ${effectType} | ${amount}`);
@@ -348,7 +339,7 @@ export class BattleEffect extends Phaser.GameObjects.Container {
             targets: this,
             alpha: 0,
             delay: 250,
-            duration: 500,
+            duration: 1500,
             onComplete: () => {
                 //console.log(`BattleEffect COMPLETE ${effectType} | ${amount}`);
                 onComplete();


### PR DESCRIPTION
Removes EFFECT_TYPE.generate and replaces it with a separate energy generation attribute on the ability.

Abilities can no longer trigger their own energy triggers.

Abilities repreent this new innate energy generation by changing the background tint.