### PR TITLE
Dynamic witness div-mod

### DIFF
--- a/contract/src/generate.js
+++ b/contract/src/generate.js
@@ -16,10 +16,7 @@ function codegen_placeholders() {
         .replaceAll('INSERT_ENEMY_DAMAGE_CODE_HERE', gen_enemy_dmg())
         .replaceAll('INSERT_ENEMY_BLOCK_CODE_HERE', gen_enemy_block())
         .replaceAll('INSERT_DECK_INDEX_CALCULATION_CODE_HERE', gen_deck_index_calculation())
-        .replaceAll('INSERT_DECK_INDEX_BATTLE_STATE_INIT_CODE_HERE', gen_deck_index_eval())
-        .replaceAll('INSERT_RNG_MOD_CIRCUIT_HERE', gen_rng_mod_circuits())
-        .replaceAll('INSERT_MAX_RNG_MOD_DEFS', MAX_RNG_MOD_DEFS.toString())
-        .replaceAll('INSERT_RNG_MOD_INPUT_TYPE', `Uint<0..${MAX_RNG_MOD_DEFS}>`);
+        .replaceAll('INSERT_DECK_INDEX_BATTLE_STATE_INIT_CODE_HERE', gen_deck_index_eval());
     fs.writeFileSync('src/game2.compact', `// AUTO-GENERATED - **DO NOT MODIFY**\n// PLEASE CHANGE template.compact INSTEAD!\n\n${replaced}`);
 }
 
@@ -94,32 +91,6 @@ const gen_deck_index_calculation = () => abilities.map((a) => {
 
 const gen_deck_index_eval = () => `[${abilities.map((a) => `new_deck_${a}`).join()}]`;
 
-
-
-// rng helpers
-// until we get foreign field arithmetic we're stuck with this
-const gen_rng_mod_circuit = (mod) => {
-    const subtract_amount = mod;
-
-    const repeated_subtract = `// repeated subtract\n    ${new Array(Math.floor(256 / subtract_amount)).fill(0).map((_, i) => `${i == 0 ? '' : 'else '}if (rng < ${subtract_amount * (i + 1)}) {\n        return rng${i == 0 ? `` : ` - ${subtract_amount * i}`};\n    }`).join(' ')}
-    return rng - ${256 - mod};`;
-
-    const buckets = `// buckets\n    ${new Array(mod - 1).fill(0).map((_, i) => `${i == 0 ? '' : 'else '}if (rng < ${Math.floor((i + 1) * (256 / mod))}) {\n        return ${i};\n    }`).join(' ')}
-    return ${mod - 1};`;
-
-    // see which approach generates the smaller circuit and use this
-    return `pure circuit rng_mod_${mod}(rng: Uint<8>): Uint<8> {
-    ${repeated_subtract.length < buckets.length ? repeated_subtract : buckets}
-}`};
-
-const gen_rng_mod_circuits = () => `pure circuit rng_mod(rng: Uint<8>, mod: Uint<0..${MAX_RNG_MOD_DEFS}>): Uint<8> {
-    if (mod == 1) {
-        return 0;
-    } ${new Array(MAX_RNG_MOD_DEFS - 2).fill(0).map((_, i) => `else if (mod == ${i + 2}) {\n        return rng_mod_${i + 2}(rng);\n    }`).join(' ')}
-    return rng_mod_${MAX_RNG_MOD_DEFS}(rng);
-}
-
-${new Array(MAX_RNG_MOD_DEFS - 1).fill(0).map((_, i) => gen_rng_mod_circuit(i + 2)).join('\n\n')}`;
 
 
 codegen_placeholders();

--- a/contract/src/template.compact
+++ b/contract/src/template.compact
@@ -145,6 +145,27 @@ constructor() {
     players.resetToDefault();
 }
 
+// raw witness to do division/mod
+// do not use directly - output must be validated
+// please call div() and mod() circuits instead
+witness divMod(x: Uint<32>, y: Uint<32>): [Uint<32>, Uint<32>];
+
+export circuit div(x: Uint<32>, y: Uint<32>): Uint<32> {
+    const res = disclose(divMod(x, y));
+    const quotient = res[0];
+    const remainder = res[1];
+    assert(remainder < y && x == y * quotient + remainder, "Invalid divMod witness impl");
+    return quotient;
+}
+
+export circuit mod(x: Uint<32>, y: Uint<32>): Uint<32> {
+    const res = disclose(divMod(x, y));
+    const quotient = res[0];
+    const remainder = res[1];
+    assert(remainder < y && x == y * quotient + remainder, "Invalid divMod witness impl");
+    return remainder;
+}
+
 // used to compute player ID. secret witness only known to the player.
 witness player_secret_key(): Bytes<32>;
 
@@ -377,32 +398,40 @@ export circuit start_new_quest(loadout: PlayerLoadout, level: Level): Field {
     return quest_id;
 }
 
-export pure circuit random_ability(rng: Vector<32, Uint<8>>, difficulty: Uint<32>): Ability {
-    const color = rng_mod_6(0/*rng[0]*/);
-    const trigger1 = color != 0 && rng_mod_3(0/*rng[1]*/) == 0;
-    const trigger2 = color != 1 && rng_mod_3(0/*rng[2]*/) == 0;
-    const trigger3 = color != 2 && rng_mod_3(0/*rng[3]*/) == 0;
+// until compact 0.26 working with bytes to vec data is broken (compiles but crashes at runtime)
+// so we mock this out on-chain just using a generator element for the Z_256 group that looks semi-random
+ledger mock_rng_val: Uint<8>;
+circuit mock_rng_byte(): Uint<8> {
+    mock_rng_val = (add_mod(mock_rng_val, 23, 256)) as Uint<8>;
+    return mock_rng_val;
+}
+
+circuit random_ability(rng: Vector<32, Uint<8>>, difficulty: Uint<32>): Ability {
+    const color = mod(mock_rng_byte()/*rng[0]*/, 6);
+    const trigger1 = color != 0 && mod(mock_rng_byte()/*rng[1]*/, 3) == 0;
+    const trigger2 = color != 1 && mod(mock_rng_byte()/*rng[2]*/, 3) == 0;
+    const trigger3 = color != 2 && mod(mock_rng_byte()/*rng[3]*/, 3) == 0;
     const main_factor = difficulty * (trigger1 ? 0 : 1) + (trigger2 ? 0 : 1) + (trigger3 ? 0 : 1) + (color <= 2 ? 0 : 1);
-    const main_effect = random_effect(0/*rng[4]*/, main_factor as Uint<32>);
+    const main_effect = random_effect(mock_rng_byte()/*rng[4]*/, main_factor as Uint<32>);
     const trigger_factor = (2 * difficulty) as Uint<32>;
     return Ability {
         some<Effect>(main_effect),
         [
-            trigger1 ? some<Effect>(random_effect(0/*rng[5]*/, trigger_factor)) : none<Effect>(),
-            trigger2 ? some<Effect>(random_effect(0/*rng[6]*/, trigger_factor)) : none<Effect>(),
-            trigger3 ? some<Effect>(random_effect(0/*rng[7]*/, trigger_factor)) : none<Effect>()
+            trigger1 ? some<Effect>(random_effect(mock_rng_byte()/*rng[5]*/, trigger_factor)) : none<Effect>(),
+            trigger2 ? some<Effect>(random_effect(mock_rng_byte()/*rng[6]*/, trigger_factor)) : none<Effect>(),
+            trigger3 ? some<Effect>(random_effect(mock_rng_byte()/*rng[7]*/, trigger_factor)) : none<Effect>()
         ],
         color <= 2 ? some<Uint<0..2>>(color as Uint<0..2>) : none<Uint<0..2>>(),
         0
     };
 }
 
-pure circuit random_effect(rng: Uint<8>, factor: Uint<32>): Effect {
-    const effect_type = cast_to_effect_type(rng_mod_4(rng) as Uint<0..4>);
+circuit random_effect(rng: Uint<8>, factor: Uint<32>): Effect {
+    const effect_type = cast_to_effect_type(mod(rng, 4) as Uint<0..4>);
     const aoe = effect_type != EFFECT_TYPE.block ? rng > 180 : false;
     const block_factor = effect_type != EFFECT_TYPE.block ? 1 : 5;
     const final_factor = factor * block_factor * (aoe ? 1 : 2);
-    const amount = final_factor + rng_mod(rng, final_factor as INSERT_RNG_MOD_INPUT_TYPE);
+    const amount = final_factor + mod(rng, final_factor as Uint<32>);
     return Effect {
         effect_type,
         amount as Uint<32>,
@@ -458,7 +487,7 @@ export circuit finalize_quest(quest_id: Field): Maybe<Field> {
         quest.loadout
     };
     const battle_id = derive_battle_id(battle_config);
-    active_battle_states.insert(battle_id, init_battlestate(0/*rng[0]*/, battle_config));
+    active_battle_states.insert(battle_id, init_battlestate(mock_rng_byte()/*rng[0]*/, battle_config));
     active_battle_configs.insert(battle_id, battle_config);
 
     quests.remove(disclose(quest_id));
@@ -483,20 +512,20 @@ export circuit start_new_battle(loadout: PlayerLoadout, level: Level): BattleCon
     const player_pub_key = derive_player_pub_key(disclose(player_secret_key()));
     const battle = BattleConfig {
         disclose(level),
-        get_random_enemy_config(0/*rng[0]*/, level),
+        get_random_enemy_config(mock_rng_byte()/*rng[0]*/, level),
         player_pub_key,
         disclose(loadout)
     };
     const battle_id = derive_battle_id(disclose(battle));
-    active_battle_states.insert(disclose(battle_id), init_battlestate(2/*rng[1]*/, disclose(battle)));
+    active_battle_states.insert(disclose(battle_id), init_battlestate(mock_rng_byte()/*rng[1]*/, disclose(battle)));
     active_battle_configs.insert(disclose(battle_id), disclose(battle));
 
     return battle;
 }
 
 // is there a simple way to programatically do this more efficiently (circuit size)?
-pure circuit random_deck_indices(rng: Uint<8>): Vector<3, Uint<32>> {
-    const mod_6 = rng_mod_6(rng);
+circuit random_deck_indices(rng: Uint<8>): Vector<3, Uint<32>> {
+    const mod_6 = mod(rng, 6);
     if (mod_6 == 0) {
         return [0 as Uint<8>, 1 as Uint<8>, 2 as Uint<8>];
     } else if (mod_6 == 1) {
@@ -511,7 +540,7 @@ pure circuit random_deck_indices(rng: Uint<8>): Vector<3, Uint<32>> {
     return [2 as Uint<8>, 1 as Uint<8>, 0 as Uint<8>];
 }
 
-export pure circuit init_battlestate(rng: Uint<8>, battle: BattleConfig): BattleState {
+circuit init_battlestate(rng: Uint<8>, battle: BattleConfig): BattleState {
     return BattleState {
         0,
         random_deck_indices(rng),
@@ -710,7 +739,7 @@ circuit get_player_rng(): Bytes<32> {
 }
 
 circuit get_random_enemy_config(rng: Uint<8>, level: Level): EnemiesConfig {
-    const index = 0;//rng_mod(rng, levels.lookup(level).size() as INSERT_RNG_MOD_INPUT_TYPE);
+    const index = mod(mock_rng_byte()/*rng*/, levels.lookup(level).size() as Uint<32>);
     return levels.lookup(level).lookup(index);
 }
 
@@ -739,12 +768,9 @@ export circuit admin_level_new(level: Level, boss: EnemiesConfig): [] {
 
 export circuit admin_level_add_config(level: Level, enemies: EnemiesConfig): [] {
     admin_verify();
-    assert(levels.lookup(level).size() < INSERT_MAX_RNG_MOD_DEFS, "rng_mod() not defined for this many configs");
     levels.lookup(level).insert(levels.lookup(level).size(), disclose(enemies));
 }
 
 circuit admin_verify(): [] {
     assert(derive_player_pub_key(disclose(player_secret_key())) == deployer, "Admin auth failed");
 }
-
-INSERT_RNG_MOD_CIRCUIT_HERE

--- a/contract/src/witnesses.ts
+++ b/contract/src/witnesses.ts
@@ -38,7 +38,7 @@ export const createGame2PrivateState = (secretKey: Uint8Array) => ({
  * and a Uint8Array (because the contract declared a return value of Bytes[32],
  * and that's a Uint8Array in TypeScript).
  *
- * The player_sk witness does not need the ledger or contractAddress
+ * The player_secret_key witness does not need the ledger or contractAddress
  * from the WitnessContext, so it uses the parameter notation that puts
  * only the binding for the privateState in scope.
  */
@@ -47,4 +47,14 @@ export const witnesses = {
     privateState,
     privateState.secretKey,
   ],
+  divMod: (
+    context: WitnessContext<Ledger, Game2PrivateState>,
+    x: bigint, 
+    y: bigint): [Game2PrivateState, [bigint, bigint]] => {
+    const xn = Number(x);
+    const yn = Number(y);
+    const remainder = xn % yn;
+    const quotient = Math.floor(xn / yn);
+    return [context.privateState, [BigInt(quotient), BigInt(remainder)]];
+  }
 };

--- a/phaser/src/mockapi.ts
+++ b/phaser/src/mockapi.ts
@@ -8,7 +8,7 @@ import { ContractAddress } from "@midnight-ntwrk/ledger";
 import { DeployedGame2API, Game2DerivedState, safeJSONString } from "game2-api";
 import { Ability, BattleConfig, BattleRewards, EFFECT_TYPE, BOSS_TYPE, Level, EnemiesConfig, PlayerLoadout, pureCircuits } from "game2-contract";
 import { Observable, Subscriber, Subject } from "rxjs";
-import { combat_round_logic } from "./battle/logic";
+import { combat_round_logic, initBattlestate, randomAbility } from "./battle/logic";
 import { logger } from "./main";
 import { randomBytes } from "game2-api/dist/utils";
 
@@ -90,7 +90,7 @@ export class MockGame2API implements DeployedGame2API {
             };
             const id = pureCircuits.derive_battle_id(battle);
             logger.gameState.info(`new battle: ${id}`);
-            this.mockState.activeBattleStates.set(id, pureCircuits.init_battlestate(BigInt(Phaser.Math.Between(0, 255)), battle));
+            this.mockState.activeBattleStates.set(id, initBattlestate(Phaser.Math.Between(0, 255), battle));
             this.mockState.activeBattleConfigs.set(id, battle);
             return battle;
         });
@@ -198,7 +198,7 @@ export class MockGame2API implements DeployedGame2API {
 
                 const battleId = pureCircuits.derive_battle_id(battle_config);
 
-                this.mockState.activeBattleStates.set(battleId, pureCircuits.init_battlestate(BigInt(Phaser.Math.Between(0, 255)), battle_config));
+                this.mockState.activeBattleStates.set(battleId, initBattlestate(Phaser.Math.Between(0, 255), battle_config));
                 this.mockState.activeBattleConfigs.set(battleId, battle_config);
 
                 return battleId;
@@ -278,7 +278,7 @@ export class MockGame2API implements DeployedGame2API {
     }
 
     private givePlayerRandomAbility(difficulty: bigint): bigint {
-        const ability = pureCircuits.random_ability(Array.from(randomBytes(32)).map(BigInt), difficulty);
+        const ability = randomAbility(randomBytes(32), difficulty);
         const abilityId = pureCircuits.derive_ability_id(ability);
         this.mockState.allAbilities.set(abilityId, ability);
         this.mockState.playerAbilities.set(abilityId, (this.mockState.playerAbilities.get(abilityId) ?? BigInt(0)) + BigInt(1));


### PR DESCRIPTION
Resolves #114

Replaces all uses with this new witness-based implementation.

We now have additional circuits implemented on the JS side now as we had to change many circuits to be impure due to their usage of this new witness.

As a side-effect this fixes the mock-api's random ability always being the same thing. I also fixed this on-chain by changing the hard-coded 0's to a `mock_rng_byte()` circuit that generates Z_256 deterministically so you probably won't notice any repetition.